### PR TITLE
Updated Unit-Tests to NUnit 3.2.1 and FluentAssertions 4.6.3

### DIFF
--- a/Cyotek.Collections.Generic.CircularBuffer.Tests/CircularBufferTests.cs
+++ b/Cyotek.Collections.Generic.CircularBuffer.Tests/CircularBufferTests.cs
@@ -13,10 +13,6 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
     #region  Tests
 
     [Test]
-    [ExpectedException(typeof(ArgumentOutOfRangeException),
-      ExpectedMessage =
-        "The new capacity must be greater than or equal to the buffer size.\r\nParameter name: value\r\nActual value was 3."
-      )]
     public void CapacityExceptionTest()
     {
       // arrange
@@ -31,8 +27,9 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
       target.Put("Gamma");
       target.Put("Delta");
 
-      // act
-      target.Capacity = expected;
+      // act & assert
+      Assert.That(() => target.Capacity = expected, Throws.TypeOf<ArgumentOutOfRangeException>());
+
     }
 
     [Test]
@@ -280,7 +277,6 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
     }
 
     [Test]
-    [ExpectedException(typeof(NotSupportedException), ExpectedMessage = "Cannot remove items from collection.")]
     public void CollectionRemoveTest()
     {
       // arrange
@@ -292,19 +288,17 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
       target.Put("Gamma");
       target.Put("Delta");
 
-      // act
-      ((ICollection<string>)target).Remove("Alpha");
+      // act & assert
+      Assert.That(() => ((ICollection<string>)target).Remove("Alpha"), Throws.TypeOf<NotSupportedException>());
+
     }
 
     [Test]
-    [ExpectedException(typeof(ArgumentException),
-      ExpectedMessage = "The buffer capacity must be greater than or equal to zero.\r\nParameter name: capacity")]
     public void ConstructorCapacityExceptionTest()
     {
-      // act
-      // ReSharper disable once ObjectCreationAsStatement
-      new CircularBuffer<string>(-1);
-    }
+    // act & assert
+    Assert.That(() => new CircularBuffer<string>(-1), Throws.TypeOf<ArgumentException>());
+        }
 
     [Test]
     public void ConstructorWithCapacityAndDefaultOverflowTest()
@@ -593,9 +587,6 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
     }
 
     [Test]
-    [ExpectedException(typeof(ArgumentOutOfRangeException),
-      ExpectedMessage =
-        "The read count cannot be greater than the buffer size.\r\nParameter name: count\r\nActual value was 4.")]
     public void CopyToExceptionTest()
     {
       // arrange
@@ -616,8 +607,8 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
       target.Put("Beta");
       target.Put("Gamma");
 
-      // act
-      target.CopyTo(index, actual, offset, count);
+      // act & assert
+      Assert.That(() => target.CopyTo(index, actual, offset, count), Throws.TypeOf<ArgumentOutOfRangeException>()); 
     }
 
     [Test]
@@ -760,7 +751,6 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
     }
 
     [Test]
-    [ExpectedException(typeof(InvalidOperationException), ExpectedMessage = "The buffer is empty.")]
     public void GetEmptyExceptionTest()
     {
       // arrange
@@ -774,8 +764,8 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
       target.Get();
       target.Get();
 
-      // act
-      target.Get();
+            // act & assert
+            Assert.That(() => target.Get(), Throws.TypeOf<InvalidOperationException>()); 
     }
 
     [Test]
@@ -1293,7 +1283,6 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
     }
 
     [Test]
-    [ExpectedException(typeof(InvalidOperationException), ExpectedMessage = "The buffer is empty.")]
     public void PeekArrayEmptyExceptionTest()
     {
       // arrange
@@ -1301,8 +1290,8 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
 
       target = new CircularBuffer<string>(10);
 
-      // act
-      target.Peek(2);
+      // act & assert
+      Assert.That(() => target.Peek(2), Throws.TypeOf<InvalidOperationException>());
     }
 
     [Test]
@@ -1333,7 +1322,6 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
     }
 
     [Test]
-    [ExpectedException(typeof(InvalidOperationException), ExpectedMessage = "The buffer is empty.")]
     public void PeekEmptyExceptionTest()
     {
       // arrange
@@ -1341,12 +1329,11 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
 
       target = new CircularBuffer<string>(10);
 
-      // act
-      target.Peek();
+      // act & assert
+      Assert.That(() => target.Peek(), Throws.TypeOf<InvalidOperationException>());
     }
 
     [Test]
-    [ExpectedException(typeof(InvalidOperationException), ExpectedMessage = "The buffer is empty.")]
     public void PeekLastEmptyExceptionTest()
     {
       // arrange
@@ -1354,11 +1341,11 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
 
       target = new CircularBuffer<string>(10);
 
-      // act
-      target.PeekLast();
-    }
+      // act & assert
+      Assert.That(() => target.PeekLast(), Throws.TypeOf<InvalidOperationException>());
+     }
 
-    [Test]
+        [Test]
     public void PeekLastTest()
     {
       // arrange
@@ -1428,8 +1415,6 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
     }
 
     [Test]
-    [ExpectedException(typeof(InvalidOperationException),
-      ExpectedMessage = "The buffer does not have sufficient capacity to put new items.")]
     public void PutArrayExceptionTest()
     {
       // arrange
@@ -1441,8 +1426,8 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
       target = new CircularBuffer<byte>(expected.Length, false);
       target.Put(byte.MaxValue);
 
-      // act
-      target.Put(expected);
+      // act & assert
+      Assert.That(() => target.Put(expected), Throws.TypeOf<InvalidOperationException>());
     }
 
     [Test]
@@ -1466,8 +1451,6 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
     }
 
     [Test]
-    [ExpectedException(typeof(InvalidOperationException),
-      ExpectedMessage = "The buffer does not have sufficient capacity to put new items.")]
     public void PutBufferFullExceptionTest()
     {
       // arrange
@@ -1478,8 +1461,8 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
       target.Put("Alpha");
       target.Put("Beta");
 
-      // act
-      target.Put("Gamma");
+       // act & assert
+       Assert.That(() => target.Put("Gamma"), Throws.TypeOf<InvalidOperationException>());
     }
 
     [Test]
@@ -1813,13 +1796,13 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
 
     private Random _random;
 
-    [TestFixtureTearDown]
+    [OneTimeTearDown]
     public void CleanUp()
     {
       _random = null;
     }
 
-    [TestFixtureSetUp]
+    [OneTimeSetUp]
     public void Setup()
     {
       _random = new Random();

--- a/Cyotek.Collections.Generic.CircularBuffer.Tests/Cyotek.Collections.Generic.CircularBuffer.Tests.csproj
+++ b/Cyotek.Collections.Generic.CircularBuffer.Tests/Cyotek.Collections.Generic.CircularBuffer.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Cyotek.Collections.Generic.CircularBuffer.Tests</RootNamespace>
     <AssemblyName>Cyotek.Collections.Generic.CircularBuffer.Tests</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
@@ -32,12 +32,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentAssertions, Version=2.2.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\packages\FluentAssertions.2.2.0.0\lib\net35\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.6.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.6.3.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.4.6.3\lib\net40\FluentAssertions.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.1\lib\net40\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/Cyotek.Collections.Generic.CircularBuffer.Tests/packages.config
+++ b/Cyotek.Collections.Generic.CircularBuffer.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="2.2.0.0" targetFramework="net35" />
-  <package id="NUnit" version="2.6.4" targetFramework="net35" />
+  <package id="FluentAssertions" version="4.6.3" targetFramework="net40" />
+  <package id="NUnit" version="3.2.1" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
- Replaced ExpectedException with Assert.That
- Removed ExpectedMessage because of Problems with different languages
