### PR TITLE
Fix data corruption on capacity change

### DIFF
--- a/src/CircularBuffer.cs
+++ b/src/CircularBuffer.cs
@@ -114,6 +114,8 @@ namespace Cyotek.Collections.Generic
           }
 
           _buffer = newBuffer;
+          _tail = _size;
+          _head = 0;
 
           _capacity = value;
         }

--- a/src/CircularBuffer.cs
+++ b/src/CircularBuffer.cs
@@ -66,11 +66,8 @@ namespace Cyotek.Collections.Generic
         throw new ArgumentException("The buffer capacity must be greater than or equal to zero.", nameof(capacity));
       }
 
-      _buffer = new T[capacity];
-      this.Capacity = capacity;
       _size = 0;
-      _head = 0;
-      _tail = 0;
+      this.Capacity = capacity;
       _allowOverwrite = allowOverwrite;
     }
 

--- a/tests/CircularBufferTests.cs
+++ b/tests/CircularBufferTests.cs
@@ -1806,6 +1806,32 @@ namespace Cyotek.Collections.Generic.CircularBuffer.Tests
     }
 
     [Test]
+    public void WrappedBufferResizeTest()
+    {
+      // arrange
+      CircularBuffer<string> target;
+      string[] expected;
+      string[] actual;
+
+      target = new CircularBuffer<string>(4, true);
+      target.Put("1");
+      target.Put("2");
+      target.Put("3");
+      target.Put("4");
+      target.Put("5"); //ensuring buffer is wrapped
+      target.Put("6");
+
+      expected = new[] {"3", "4", "5", "6"};
+
+      // act
+      target.Capacity = 6;
+      actual = target.ToArray();
+
+      // assert
+      Assert.AreEqual(expected, actual);
+    }
+
+    [Test]
     public void SkipOverCapacityTest()
     {
       // arrange


### PR DESCRIPTION
Fixes the data corruption when Capacity is changed and the head != 0. See test for details